### PR TITLE
Enables dependabot integration for both backend and frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
+      interval: "daily"
+    open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
     directory: "/frontend"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    


### PR DESCRIPTION
This PR configures the GitHub Dependabot to be able to scan Python packages used in backend and npm packages used in frontend.

Nothing actually happens until you enable Dependabot alerts or security updates for this repository, which you can do at:
https://github.com/cx1111/full-react-integration/settings/security_analysis

If you do that, then you will see new PRs automatically created here:
https://github.com/cx1111/full-react-integration/pulls

And the Dependabot status page will be enabled:
https://github.com/ahjota/full-react-integration/network/updates

Here's an example from my fork of this repo:
![image](https://user-images.githubusercontent.com/3588606/95529756-aa2dc900-0990-11eb-87b9-bad67ba06fda.png)

Closes #14 